### PR TITLE
Added resource for vm_extension_removal_policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,10 +161,10 @@ Attribute Parameters:
 The following parameters are inherited from the [remote_file](https://docs.chef.io/resource_remote_file.html) resource.
 
 * `owner`
-* `group` 
+* `group`
 * `mode`
 * `checksum`
-* `backup` 
+* `backup`
 * `inherits`
 * `rights`
 
@@ -238,13 +238,38 @@ Here is an example of how you might retrieve the generated server
 name.
 
     file '/etc/db_server_info' do
-      content lazy { 
+      content lazy {
         db2 = resources("microsoft_azure_sql_db_server[West US]")
         "Url: https://#{db2.server_name}.database.windows.net"
       }
       mode 0600
       action :create
     end
+
+## vm_extension_removal_policy
+This resource can be used to configure the behavior of `chef-extension` on removal. This resource should be run as the root user since it modifies the extension config file.
+
+User needs to set environment variable `EXTENSION_PATH` pointing to the extension root path e.g. `C:/Packages/Plugins/Chef.Bootstrap.WindowsAzure.ChefClient/<extension_version>` for windows or `/var/lib/waagent/Chef.Bootstrap.WindowsAzure.LinuxChefClient-<extension_version>` for linux.
+
+NOTE: `EXTENSION_PATH` may vary from the examples mentioned above.
+
+Actions:
+
+* `set` - sets the configuration in the extension config file.
+
+Attribute Parameters:
+
+* `uninstall_chef_client` - true/false (decides whether chef-client should be uninstalled on extension uninstall). Default value is false
+* `delete_chef_config` - true/false (decides whether to delete chef extension configuration file on extension uninstall). Default value is false
+
+Example:
+
+```ruby
+azure_cookbook_vm_extension_removal_policy "set policy" do
+  uninstall_chef_client false
+  delete_chef_config true
+end
+```
 
 Helpers
 =======

--- a/providers/vm_extension_removal_policy.rb
+++ b/providers/vm_extension_removal_policy.rb
@@ -6,9 +6,10 @@ action :set do
     if ENV["extension_path"]
       # get the path of extension config file using HandlerEnvironment.json
       extension_path = ENV["extension_path"]
-      handler_environment = deserialize_json(extension_path + "/HandlerEnvironment.json")
+      handler_environment = deserialize_json(::File.join(extension_path, "HandlerEnvironment.json"))
       config_folder = handler_environment[0]["handlerEnvironment"]["configFolder"]
-      config_path = Dir[config_folder+"/*.settings"].last
+      config_folder = config_folder.gsub('\\','/')
+      config_path = Dir[::File.join(config_folder,"*.settings")].last
 
       # config file is in json format. So deserialize it
       config_json = deserialize_json(config_path)

--- a/providers/vm_extension_removal_policy.rb
+++ b/providers/vm_extension_removal_policy.rb
@@ -1,4 +1,4 @@
-include Azure::Cookbook
+
 require 'json'
 
 action :set do
@@ -17,7 +17,7 @@ action :set do
     deserialized_json["runtimeSettings"][0]["handlerSettings"]["publicSettings"]["deleteChefConfig"] = new_resource.delete_chef_config
     deserialized_json["runtimeSettings"][0]["handlerSettings"]["publicSettings"]["uninstallChefClient"] = new_resource.uninstall_chef_client
 
-    File.write(config_path, deserialized_json.json)
+    ::File.write(config_path, deserialized_json.to_json)
   rescue => error
     Chef::Log.error("#{error.message}")
   end
@@ -25,7 +25,7 @@ end
 
 def deserialize_json(file)
   # User may give file path or file content as input.
-  normalized_content = File.read(file) if File.exists?(file)
+  normalized_content = ::File.read(file) if ::File.exists?(file)
 
   begin
     JSON.parse(normalized_content)

--- a/providers/vm_extension_removal_policy.rb
+++ b/providers/vm_extension_removal_policy.rb
@@ -1,0 +1,68 @@
+include Azure::Cookbook
+require 'json'
+
+action :set do
+  begin
+    # get the path of extension config file
+    if node['platform_family'] == 'windows'
+      extension_path = Dir["C:/Packages/Plugins/Chef.Bootstrap.WindowsAzure.ChefClient/*"].last
+      config_path = Dir[extension_path+"/RuntimeSettings/*.settings"].last
+    else
+      extension_path = Dir["/var/lib/waagent/Chef.Bootstrap.WindowsAzure.LinuxChefClient-*"].last
+      config_path = Dir[extension_path+"/config/*.settings"].last
+    end
+
+    # config file is in json format. So deserialize it
+    deserialized_json = deserialize_json(config_path)
+    deserialized_json["runtimeSettings"][0]["handlerSettings"]["publicSettings"]["deleteChefConfig"] = new_resource.delete_chef_config
+    deserialized_json["runtimeSettings"][0]["handlerSettings"]["publicSettings"]["uninstallChefClient"] = new_resource.uninstall_chef_client
+
+    File.write(config_path, deserialized_json.json)
+  rescue => error
+    Chef::Log.error("#{error.message}")
+  end
+end
+
+def deserialize_json(file)
+  # User may give file path or file content as input.
+  normalized_content = File.read(file) if File.exists?(file)
+
+  begin
+    JSON.parse(normalized_content)
+  rescue JSON::ParserError => e
+    normalized_content = escape_unescaped_content(normalized_content)
+    JSON.parse(normalized_content)
+  end
+end
+
+def escape_unescaped_content(file_content)
+  lines = file_content.lines.to_a
+  # convert tabs to spaces -- technically invalidates content, but
+  # if we know the content in question treats tabs and spaces the
+  # same, we can do this.
+  untabified_lines = lines.map { | line | line.gsub(/\t/," ") }
+
+  # remove whitespace and trailing newline
+  stripped_lines = untabified_lines.map { | line | line.strip }
+  escaped_content = ""
+  line_index = 0
+
+  stripped_lines.each do | line |
+    escaped_line = line
+
+    # assume lines ending in json delimiters are not content,
+    # and that lines followed by a line that starts with ','
+    # are not content
+    if !!(line[line.length - 1] =~ /[\,\}\]]/) ||
+        (line_index < (lines.length - 1) && lines[line_index + 1][0] == ',')
+      escaped_line += "\n"
+    else
+      escaped_line += "\\n"
+    end
+
+    escaped_content += escaped_line
+    line_index += 1
+  end
+
+  escaped_content
+end

--- a/providers/vm_extension_removal_policy.rb
+++ b/providers/vm_extension_removal_policy.rb
@@ -3,9 +3,9 @@ require 'json'
 
 action :set do
   begin
-    if ENV["extension_path"]
+    if ENV["EXTENSION_PATH"]
       # get the path of extension config file using HandlerEnvironment.json
-      extension_path = ENV["extension_path"]
+      extension_path = ENV["EXTENSION_PATH"]
       handler_environment = deserialize_json(::File.join(extension_path, "HandlerEnvironment.json"))
       config_folder = handler_environment[0]["handlerEnvironment"]["configFolder"]
       config_folder = config_folder.gsub('\\','/')
@@ -18,7 +18,7 @@ action :set do
 
       ::File.write(config_path, config_json.to_json)
     else
-      Chef::Log.error("Please specify the 'extension_path' variable in the Environment variables.")
+      Chef::Log.error("Please specify the 'EXTENSION_PATH' in the Environment variables.")
     end
   rescue => error
     Chef::Log.error("#{error.message}")

--- a/resources/vm_extension_removal_policy.rb
+++ b/resources/vm_extension_removal_policy.rb
@@ -1,0 +1,9 @@
+actions :set
+
+attribute :uninstall_chef_client, :kind_of => [TrueClass, FalseClass], :default => false
+attribute :delete_chef_config, :kind_of => [TrueClass, FalseClass], :default => false
+
+def initialize(*args)
+  super
+  @action = :set
+end


### PR DESCRIPTION
LWRP for setting/updating Azure Chef extension configurations: `deleteChefConfig` and `uninstallChefClient`.